### PR TITLE
Calculate case notifications from incidence using an observation model

### DIFF
--- a/emu_renewal/calibration.py
+++ b/emu_renewal/calibration.py
@@ -54,6 +54,7 @@ class StandardCalib(Calibration):
         priors: dict[str, dist.Distribution],
         data: pd.Series,
         fixed_params: Dict[str, float]={},
+        indicator: str="cases",
     ):
         """Set up calibration object with epi model and data.
 
@@ -65,6 +66,7 @@ class StandardCalib(Calibration):
         self.data_disp_sd = 0.1
         self.proc_disp_sd = 0.1
         self.fixed_params = fixed_params
+        self.indicator = indicator
 
     def get_model_notifications(
         self, 
@@ -79,7 +81,7 @@ class StandardCalib(Calibration):
             Modelled time series of cases over analysis period
         """
         result = self.epi_model.renewal_func(**params)
-        return result.cases[self.common_model_idx]
+        return getattr(result, self.indicator)[self.common_model_idx]
 
     def calibration(self):
         """See get_description below.

--- a/emu_renewal/renew.py
+++ b/emu_renewal/renew.py
@@ -179,7 +179,8 @@ class RenewalModel:
         report_sd: float,
         cdr: float,
     ) -> jnp.array:
-        """The observation model
+        """The observation model. Note that this code is constrained to have
+        the same distribution type for the reporting delay as for the renewal process.
 
         Args:
             inc: The modelled incidence

--- a/emu_renewal/renew.py
+++ b/emu_renewal/renew.py
@@ -25,7 +25,8 @@ class ModelResult(NamedTuple):
     r_t: jnp.array
     process: jnp.array
     cases: jnp.array
-    other_cases: jnp.array
+    convolved_cases: jnp.array
+    weekly_sum: jnp.array
 
 
 class RenewalModel:
@@ -268,7 +269,9 @@ class RenewalModel:
             return RenewalState(incidence, suscept), out
 
         end_state, outputs = lax.scan(state_update, init_state, self.model_times)
-        outputs["convolved_cases"] = self.get_cases_from_inc(outputs["incidence"], report_mean, report_sd, cdr)
+        convolved_cases = self.get_cases_from_inc(outputs["incidence"], report_mean, report_sd, cdr)
+        outputs["convolved_cases"] = convolved_cases
+        outputs["weekly_sum"] = jnp.convolve(convolved_cases, jnp.array([1] * 7))[:-6]
         return ModelResult(**outputs)
 
     def describe_renewal(self):

--- a/emu_renewal/renew.py
+++ b/emu_renewal/renew.py
@@ -190,7 +190,18 @@ class RenewalModel:
             densities = self.report_dist.get_densities(len(latent_state), report_mean, report_sd)
             return (latent_state * densities).sum() * cdr
         return delay_report_func
-
+    
+    def alternate_delay_report(self, report_mean, report_sd, cdr):
+        def delay_report_func(latent_state):
+            n_times = 7
+            densities = self.report_dist.get_densities(len(latent_state), report_mean, report_sd)
+            result = 0.0
+            for i in range(n_times):
+                dens = densities[:-i] if i > 0 else densities  # Because indexing with [:-0] gives an empty array
+                result += (latent_state[i:] * dens).sum()
+            return result * cdr / n_times
+        return delay_report_func
+    
     def renewal_func(
         self, 
         gen_mean: float, 
@@ -216,7 +227,7 @@ class RenewalModel:
         init_inc = self.init_series / cdr
         start_pop = self.pop - jnp.sum(init_inc)
         init_state = RenewalState(init_inc, start_pop)
-        delay_report = self.get_delay_report(report_mean, report_sd, cdr)
+        delay_report = self.alternate_delay_report(report_mean, report_sd, cdr)
 
         def state_update(state: RenewalState, t) -> tuple[RenewalState, jnp.array]:
             proc_val = process_vals[t - self.start]

--- a/emu_renewal/renew.py
+++ b/emu_renewal/renew.py
@@ -226,7 +226,7 @@ class RenewalModel:
         """
         full_inc = jnp.concatenate([init_inc, jnp.array(inc)])
         densities = self.dens_obj.get_densities(len(full_inc), report_mean, report_sd)
-        result = [(densities[i:0:-1] * full_inc[:i]).sum() * cdr for i in range(len(full_inc))]
+        result = [(densities[i:0:-1] * full_inc[:i]).sum() * cdr for i in range(len(full_inc))][len(init_inc):]
         return jnp.array(result, float)  # Otherwise the elements come out as 1-element arrays
 
     def renewal_func(

--- a/emu_renewal/renew.py
+++ b/emu_renewal/renew.py
@@ -174,7 +174,7 @@ class RenewalModel:
     def get_cases_from_inc(
         self, 
         inc: jnp.array, 
-        init_inc,
+        init_inc: jnp.array,
         report_mean: float,
         report_sd: float,
         cdr: float,
@@ -183,6 +183,7 @@ class RenewalModel:
 
         Args:
             inc: The modelled incidence
+            init_inc: Initialisation incidence series
             report_mean: Mean reporting delay parameter
             report_sd: Standard deviation of the reporting delay parameter
             cdr: The case detection proportion

--- a/emu_renewal/renew.py
+++ b/emu_renewal/renew.py
@@ -248,7 +248,7 @@ class RenewalModel:
         end_state, outputs = lax.scan(state_update, init_state, self.model_times)
 
         full_inc = jnp.concatenate([init_inc, jnp.array(outputs["incidence"])])
-        outputs["other_cases"] = [(densities[i:0:-1] * full_inc[:i]).sum() * cdr for i in range(len(full_inc))]
+        outputs["other_cases"] = jnp.array([(densities[i:0:-1] * full_inc[:i]).sum() * cdr for i in range(len(full_inc))], float)
 
         return ModelResult(**outputs)
 

--- a/notebooks/03-covid-malaysia.ipynb
+++ b/notebooks/03-covid-malaysia.ipynb
@@ -160,13 +160,6 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
    "source": [
     "pd.DataFrame(\n",
     "    {\n",

--- a/notebooks/03-covid-malaysia.ipynb
+++ b/notebooks/03-covid-malaysia.ipynb
@@ -143,15 +143,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "parameters = {i: j for i, j in sample_params.iloc[0].items() if \"dispersion\" not in i}"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "parameters = {i: j for i, j in sample_params.iloc[0].items() if \"dispersion\" not in i}\n",
     "result = renew_model.renewal_func(**parameters)"
    ]
   },
@@ -161,40 +153,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from jax import numpy as jnp"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "full_inc = jnp.concatenate([renew_model.init_series, jnp.array(result.incidence)])\n",
-    "densities = renew_model.dens_obj.get_densities(len(full_inc), parameters[\"report_mean\"], parameters[\"report_sd\"])\n",
-    "case_result = [(densities[i:0:-1] * full_inc[:i]).sum() * parameters[\"cdr\"] for i in range(len(full_inc))][len(renew_model.init_series):]\n",
-    "cases = jnp.array(result, float)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "jnp.convolve(densities[::-1], full_inc)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "import numpy as np\n",
     "pd.DataFrame(\n",
     "    {\n",
-    "        \"other_cases\": list(result.other_cases),\n",
-    "        \"cases\": list(result.cases),\n",
+    "        \"convolved_cases\": np.array(result.other_cases),\n",
+    "        \"cases\": np.array(result.cases),\n",
     "    }\n",
     ").plot()"
    ]

--- a/notebooks/03-covid-malaysia.ipynb
+++ b/notebooks/03-covid-malaysia.ipynb
@@ -161,6 +161,36 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from jax import numpy as jnp"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "full_inc = jnp.concatenate([renew_model.init_series, jnp.array(result.incidence)])\n",
+    "densities = renew_model.dens_obj.get_densities(len(full_inc), parameters[\"report_mean\"], parameters[\"report_sd\"])\n",
+    "case_result = [(densities[i:0:-1] * full_inc[:i]).sum() * parameters[\"cdr\"] for i in range(len(full_inc))][len(renew_model.init_series):]\n",
+    "cases = jnp.array(result, float)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "jnp.convolve(densities[::-1], full_inc)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "pd.DataFrame(\n",
     "    {\n",
     "        \"other_cases\": list(result.other_cases),\n",

--- a/notebooks/03-covid-malaysia.ipynb
+++ b/notebooks/03-covid-malaysia.ipynb
@@ -163,7 +163,7 @@
    "source": [
     "pd.DataFrame(\n",
     "    {\n",
-    "        \"other_cases\": list(result.other_cases)[50:],\n",
+    "        \"other_cases\": list(result.other_cases),\n",
     "        \"cases\": list(result.cases),\n",
     "    }\n",
     ").plot()"

--- a/notebooks/03-covid-malaysia.ipynb
+++ b/notebooks/03-covid-malaysia.ipynb
@@ -152,8 +152,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "renew_model.renewal_func(**parameters)"
+    "result = renew_model.renewal_func(**parameters)"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "code",

--- a/notebooks/03-covid-malaysia.ipynb
+++ b/notebooks/03-covid-malaysia.ipynb
@@ -143,6 +143,24 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "parameters = {i: j for i, j in sample_params.iloc[0].items() if \"dispersion\" not in i}"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "renew_model.renewal_func(**parameters)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "pd.DataFrame(\n",
     "    {\n",
     "        \"other_cases\": list(result.other_cases)[50:],\n",

--- a/notebooks/03-covid-malaysia.ipynb
+++ b/notebooks/03-covid-malaysia.ipynb
@@ -136,6 +136,20 @@
    "source": [
     "plot_post_prior_comparison(idata, list(priors.keys()), priors);"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pd.DataFrame(\n",
+    "    {\n",
+    "        \"other_cases\": list(result.other_cases)[50:],\n",
+    "        \"cases\": list(result.cases),\n",
+    "    }\n",
+    ").plot()"
+   ]
   }
  ],
  "metadata": {

--- a/notebooks/03-covid-malaysia.ipynb
+++ b/notebooks/03-covid-malaysia.ipynb
@@ -156,7 +156,7 @@
     "import numpy as np\n",
     "pd.DataFrame(\n",
     "    {\n",
-    "        \"convolved_cases\": np.array(result.other_cases),\n",
+    "        \"convolved_cases\": np.array(result.convolved_cases),\n",
     "        \"cases\": np.array(result.cases),\n",
     "    }\n",
     ").plot()"

--- a/notebooks/03-covid-malaysia.ipynb
+++ b/notebooks/03-covid-malaysia.ipynb
@@ -165,8 +165,8 @@
     "import numpy as np\n",
     "pd.DataFrame(\n",
     "    {\n",
-    "        \"convolved_cases\": np.array(result.cases),\n",
-    "        \"cases\": np.array(result.weekly_sum),\n",
+    "        \"cases\": np.array(result.cases),\n",
+    "        \"weekly_case\": np.array(result.weekly_sum),\n",
     "    }\n",
     ").plot()"
    ]

--- a/notebooks/03-covid-malaysia.ipynb
+++ b/notebooks/03-covid-malaysia.ipynb
@@ -153,15 +153,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result.weekly_sum"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "import numpy as np\n",
     "pd.DataFrame(\n",
     "    {\n",

--- a/notebooks/03-covid-malaysia.ipynb
+++ b/notebooks/03-covid-malaysia.ipynb
@@ -153,11 +153,20 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "result.weekly_sum"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import numpy as np\n",
     "pd.DataFrame(\n",
     "    {\n",
-    "        \"convolved_cases\": np.array(result.convolved_cases),\n",
-    "        \"cases\": np.array(result.cases),\n",
+    "        \"convolved_cases\": np.array(result.cases),\n",
+    "        \"cases\": np.array(result.weekly_sum),\n",
     "    }\n",
     ").plot()"
    ]


### PR DESCRIPTION
Use convolutions to apply an observation model to the renewal process. Allows for more general outputs, such as weekly totals.